### PR TITLE
Document behaviour of instructions larger than _***

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Instruction set
 * `IF MIN   -**-` - Jumps to the specified address if register has value 0 = `--------`. 
 * `SHIFT R -***` - Moves every bit of the register one spot to the right. This way rightmost bit gets lost, and a leftmost becomes '*-*'. This is the only instruction that doesn't use the address part, making the last four bits irrelevant.  
 
+Any instruction after `SHIFT R -***` (*xxx) is interpreted as a READ instruction.
+
 How to run on…
 --------------
 


### PR DESCRIPTION
Just wanted to put it in the README so people wouldn't need to read the source.
