### PR TITLE
Add shiftLeft and setImmediate instructions

### DIFF
--- a/src/comp.cpp
+++ b/src/comp.cpp
@@ -21,7 +21,7 @@
 using namespace std;
 
 extern "C" {
-	typedef void (*callback_function)(void); 
+	typedef void (*callback_function)(void);
 	void setEnvironment();
 	void setOutput(callback_function drawScreen, int width, int height);
 	void printCharXY(char c, int x, int y);
@@ -91,7 +91,7 @@ void switchBitUnderCursor() {
 
 void run() {
 	if (executionCounter > 0) {
-    	printer.print("            \n");	
+    	printer.print("            \n");
     }
 	savedRam = ram.state;
 	cpu.exec();
@@ -248,7 +248,7 @@ void Ram::set(vector<bool> adr, vector<bool> wordIn) {
 		char formatedInt [4];
 		sprintf(formatedInt, "%3d", Util::getInt(wordIn));
 		string outputLine = Util::getString(wordIn) + " " + formatedInt + "\n";
-        printer.print(outputLine);			
+        printer.print(outputLine);
 	}
 }
 
@@ -262,7 +262,7 @@ void Cpu::exec() {
 		return;
 	}
 
-	cycle++;     
+	cycle++;
 	redrawScreen();
 
 	// Stop if reached last address
@@ -273,9 +273,9 @@ void Cpu::exec() {
 	vector<bool> instruction = getInstruction();
 	int instCode = Util::getInt(instruction);
 	vector<bool> adr = getAddress();
-	
+
 	switch (instCode) {
-		case 0: 
+		case 0:
 			read(adr);
 			break;
 		case 1:
@@ -299,6 +299,12 @@ void Cpu::exec() {
 		case 7:
 			shiftRight();
 			break;
+        case 8:
+            shiftLeft();
+            break;
+        case 9:
+            setImmediate(adr);
+            break;
 		default:
 			read(adr);
 	}
@@ -327,7 +333,7 @@ vector<bool> Cpu::getInstruction() {
 }
 
 vector<bool> Cpu::getAddress() {
-	return Util::getSecondNibble(ram.get(pc)); 
+	return Util::getSecondNibble(ram.get(pc));
 }
 
 void Cpu::increasePc() {
@@ -346,7 +352,7 @@ void Cpu::write(vector<bool> adr) {
 
 void Cpu::add(vector<bool> adr) {
 	reg = Util::getBoolByte(Util::getInt(reg) + Util::getInt(ram.get(adr)));
-	increasePc();			
+	increasePc();
 }
 
 void Cpu::sub(vector<bool> adr) {
@@ -376,7 +382,17 @@ void Cpu::jumpIfMin(vector<bool> adr) {
 
 void Cpu::shiftRight() {
 	reg = Util::getBoolByte(Util::getInt(reg) / 2);
-	increasePc();	
+	increasePc();
+}
+
+void Cpu::shiftLeft() {
+    reg = Util::getBoolByte(Util::getInt(reg) * 2);
+    increasePc();
+}
+
+void Cpu::setImmediate(vector<bool> adr) {
+    reg = Util::getBoolByte(Util::getInt(adr));
+    increasePc();
 }
 
 /*

--- a/src/comp.cpp
+++ b/src/comp.cpp
@@ -91,8 +91,8 @@ void switchBitUnderCursor() {
 
 void run() {
 	if (executionCounter > 0) {
-    	printer.print("            \n");
-    }
+		printer.print("            \n");
+	}
 	savedRam = ram.state;
 	cpu.exec();
 	// if 'esc' was pressed then it doesn't wait for keypress at the end
@@ -248,7 +248,7 @@ void Ram::set(vector<bool> adr, vector<bool> wordIn) {
 		char formatedInt [4];
 		sprintf(formatedInt, "%3d", Util::getInt(wordIn));
 		string outputLine = Util::getString(wordIn) + " " + formatedInt + "\n";
-        printer.print(outputLine);
+		printer.print(outputLine);
 	}
 }
 
@@ -299,12 +299,12 @@ void Cpu::exec() {
 		case 7:
 			shiftRight();
 			break;
-        case 8:
-            shiftLeft();
-            break;
-        case 9:
-            setImmediate(adr);
-            break;
+		case 8:
+			shiftLeft();
+			break;
+		case 9:
+			setImmediate(adr);
+			break;
 		default:
 			read(adr);
 	}
@@ -386,13 +386,13 @@ void Cpu::shiftRight() {
 }
 
 void Cpu::shiftLeft() {
-    reg = Util::getBoolByte(Util::getInt(reg) * 2);
-    increasePc();
+	reg = Util::getBoolByte(Util::getInt(reg) * 2);
+	increasePc();
 }
 
 void Cpu::setImmediate(vector<bool> adr) {
-    reg = Util::getBoolByte(Util::getInt(adr));
-    increasePc();
+	reg = Util::getBoolByte(Util::getInt(adr));
+	increasePc();
 }
 
 /*

--- a/src/const.hpp
+++ b/src/const.hpp
@@ -10,6 +10,6 @@ const int RAM_SIZE = 15;
 // Miliseconds between cycles (if automatic)
 const int FQ = 333;
 
-const int NUM_OF_INSTRUCTIONS = 8;
+const int NUM_OF_INSTRUCTIONS = 10;
 
 #endif

--- a/src/cpu.hpp
+++ b/src/cpu.hpp
@@ -28,8 +28,8 @@ class Cpu {
 		void jumpIfMax(vector<bool> adr);
 		void jumpIfMin(vector<bool> adr);
 		void shiftRight();
-        void shiftLeft();
-        void setImmediate(vector<bool> adr);
+		void shiftLeft();
+		void setImmediate(vector<bool> adr);
 };
 
 #endif

--- a/src/cpu.hpp
+++ b/src/cpu.hpp
@@ -12,7 +12,7 @@ class Cpu {
 		void exec();
 		vector<bool> getRegister();
 		vector<bool> getPc();
-		vector<bool> getInstruction(); 
+		vector<bool> getInstruction();
 		vector<bool> getAddress();
 		int getCycle();
 	private:
@@ -28,6 +28,8 @@ class Cpu {
 		void jumpIfMax(vector<bool> adr);
 		void jumpIfMin(vector<bool> adr);
 		void shiftRight();
+        void shiftLeft();
+        void setImmediate(vector<bool> adr);
 };
 
 #endif


### PR DESCRIPTION
These instructions are hidden for now, because I can't get the `drawing.hpp` script to run on the version of `head` that ships with OS X to add them in there.

setImmediate is limited in that it can only accept a 4 bit integer, but in practise I only want it to set the register to 0 or 1 so it's not a huge limitation.

I think with the setImmediate instruction it will be possible to write a fibonacci generator that resets when it saturates the register :)
